### PR TITLE
feat: Add navigation:show-menu command

### DIFF
--- a/app/Console/Commands/ShowNavigationMenu.php
+++ b/app/Console/Commands/ShowNavigationMenu.php
@@ -12,6 +12,8 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
+use function Laravel\Prompts\select;
+
 class ShowNavigationMenu extends Command
 {
     /**
@@ -19,7 +21,7 @@ class ShowNavigationMenu extends Command
      *
      * @var string
      */
-    protected $signature = 'navigation:show-menu {menu} {user?}';
+    protected $signature = 'navigation:show-menu {menu?} {user?}';
 
     /**
      * The console command description.
@@ -33,7 +35,11 @@ class ShowNavigationMenu extends Command
      */
     public function handle(NavigationRegistry $registry): int
     {
-        $menuKey = $this->argument('menu');
+        $menuKey = $this->getMenuKey($registry);
+        if ($menuKey === null) {
+            return static::FAILURE;
+        }
+
         $userId = $this->argument('user');
 
         $user = null;
@@ -76,10 +82,39 @@ class ShowNavigationMenu extends Command
         return static::SUCCESS;
     }
 
+    /**
+     * Returns the key of the menu to show
+     * - grabbed from the argument if set
+     * - or via a select prompt if not
+     */
+    protected function getMenuKey(NavigationRegistry $registry): ?string
+    {
+        $menuKey = $this->argument('menu');
+
+        if (! $menuKey) {
+            $registeredKeys = $registry->registeredMenuKeys();
+            if ($registeredKeys->isEmpty()) {
+                $this->error('No menus are registered.');
+
+                return null;
+            }
+
+            $menuKey = select(
+                label: 'Which menu would you like to view?',
+                options: $registeredKeys->toArray()
+            );
+        }
+
+        return $menuKey;
+    }
+
+    /**
+     * Render an individual item to the console
+     */
     protected function renderItem(MenuItem|MenuChildItem $item, string $prefix, bool $isLast): void
     {
         $connector = $isLast ? '└── ' : '├── ';
-        $this->line($prefix.$connector.$this->itemLabel($item));
+        $this->line($prefix.$connector.$this->itemRowText($item));
 
         $newPrefix = $prefix.($isLast ? '    ' : '│   ');
 
@@ -94,7 +129,10 @@ class ShowNavigationMenu extends Command
         }
     }
 
-    protected function itemLabel(MenuItem|MenuChildItem $item): string
+    /**
+     * Return the text that should be shown for the given item
+     */
+    protected function itemRowText(MenuItem|MenuChildItem $item): string
     {
         $labelParts = [
             '['.Str::padLeft($item->sortOrder, 3, '0').']',

--- a/app/Console/Commands/ShowNavigationMenu.php
+++ b/app/Console/Commands/ShowNavigationMenu.php
@@ -89,7 +89,7 @@ class ShowNavigationMenu extends Command
      */
     protected function getMenuKey(NavigationRegistry $registry): ?string
     {
-        $menuKey = $this->argument('menu');
+        $menuKey = (string) $this->argument('menu');
 
         if (! $menuKey) {
             $registeredKeys = $registry->registeredMenuKeys();
@@ -99,7 +99,7 @@ class ShowNavigationMenu extends Command
                 return null;
             }
 
-            $menuKey = select(
+            $menuKey = (string) select(
                 label: 'Which menu would you like to view?',
                 options: $registeredKeys->toArray()
             );
@@ -135,7 +135,7 @@ class ShowNavigationMenu extends Command
     protected function itemRowText(MenuItem|MenuChildItem $item): string
     {
         $labelParts = [
-            '['.Str::padLeft($item->sortOrder, 3, '0').']',
+            '['.Str::padLeft((string) $item->sortOrder, 3, '0').']',
         ];
 
         $labelParts[] = $item->label != null ? $item->label : $item->key;

--- a/app/Console/Commands/ShowNavigationMenu.php
+++ b/app/Console/Commands/ShowNavigationMenu.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Services\Navigation\Data\MenuChildItem;
+use App\Services\Navigation\Data\MenuItem;
+use App\Services\Navigation\Enums\MenuItemType;
+use App\Services\Navigation\Exceptions\MenuKeyDoesNotExistException;
+use App\Services\Navigation\NavigationRegistry;
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+class ShowNavigationMenu extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'navigation:show-menu {menu} {user?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Displays a tree view of the requested navigation menu';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(NavigationRegistry $registry): int
+    {
+        $menuKey = $this->argument('menu');
+        $userId = $this->argument('user');
+
+        $user = null;
+        if ($userId) {
+            $user = User::find($userId);
+            if (! $user) {
+                $this->error("User with ID {$userId} not found.");
+
+                return static::FAILURE;
+            }
+        }
+
+        try {
+            $sections = $registry->resolveForUser($menuKey, $user);
+        } catch (MenuKeyDoesNotExistException $e) {
+            $this->error("Menu with key '{$menuKey}' does not exist.");
+
+            return static::FAILURE;
+        }
+
+        $this->info("Menu: {$menuKey}");
+
+        $allItems = collect();
+        foreach ($sections as $sectionItems) {
+            foreach ($sectionItems as $item) {
+                $allItems->push($item);
+            }
+        }
+
+        $itemCount = $allItems->count();
+        $itemIndex = 0;
+
+        foreach ($allItems as $item) {
+            $itemIndex++;
+            $isLastItem = $itemIndex === $itemCount;
+
+            $this->renderItem($item, '', $isLastItem);
+        }
+
+        return static::SUCCESS;
+    }
+
+    protected function renderItem(MenuItem|MenuChildItem $item, string $prefix, bool $isLast): void
+    {
+        $connector = $isLast ? '└── ' : '├── ';
+        $this->line($prefix.$connector.$this->itemLabel($item));
+
+        $newPrefix = $prefix.($isLast ? '    ' : '│   ');
+
+        $children = $item->children ?? collect();
+        $childCount = $children->count();
+        $childIndex = 0;
+
+        foreach ($children as $child) {
+            $childIndex++;
+            $childIsLast = $childIndex === $childCount;
+            $this->renderItem($child, $newPrefix, $childIsLast);
+        }
+    }
+
+    protected function itemLabel(MenuItem|MenuChildItem $item): string
+    {
+        $labelParts = [
+            '['.Str::padLeft($item->sortOrder, 3, '0').']',
+        ];
+
+        $labelParts[] = $item->label != null ? $item->label : $item->key;
+
+        if (get_class($item) === MenuItem::class) {
+            $labelParts[] = '('.($item->type != null ? $item->type->value : MenuItemType::LINK->value).')';
+        }
+
+        $transformed = $item->toArray();
+        $to = Arr::get($transformed, 'to');
+        if ($to != null) {
+            $labelParts[] = '-> '.$to;
+        }
+
+        return Arr::join($labelParts, ' ');
+    }
+}

--- a/app/Services/Navigation/NavigationRegistry.php
+++ b/app/Services/Navigation/NavigationRegistry.php
@@ -111,6 +111,16 @@ class NavigationRegistry
     }
 
     /**
+     * Returns the keys of any registered menus
+     *
+     * @return Collection<int, string>
+     */
+    public function registeredMenuKeys(): Collection
+    {
+        return $this->menus->keys()->sort()->values();
+    }
+
+    /**
      * Returns the Menu with the given key, if it exists
      *
      * @throws MenuKeyDoesNotExistException

--- a/tests/Unit/Services/Navigation/NavigationRegistryTest.php
+++ b/tests/Unit/Services/Navigation/NavigationRegistryTest.php
@@ -62,3 +62,19 @@ describe('resolveForUser', function () {
         expect($resolved)->toBe($expectedCollection);
     });
 });
+
+describe('registeredMenuKeys', function () {
+    it('returns an empty collection when no menus are registered', function () {
+        expect($this->registry->registeredMenuKeys()->isEmpty())->toBeTrue();
+    });
+
+    it('returns a sorted collection of registered menu keys', function () {
+        $this->registry->addMenu(new Menu, 'zebra');
+        $this->registry->addMenu(new Menu, 'alpha');
+        $this->registry->addMenu(new Menu, 'main');
+
+        $keys = $this->registry->registeredMenuKeys();
+
+        expect($keys->toArray())->toBe(['alpha', 'main', 'zebra']);
+    });
+});


### PR DESCRIPTION
The command makes it easy to quickly see what menu items will be rendered for a given menu and (optionally) user